### PR TITLE
__iter__ should always return iterator object instance

### DIFF
--- a/flask_sqlalchemy_cache/core.py
+++ b/flask_sqlalchemy_cache/core.py
@@ -45,7 +45,7 @@ class CachingQuery(BaseQuery):
         """
         if hasattr(self, '_cache'):
             func = lambda: list(BaseQuery.__iter__(self))
-            return self.get_value(createfunc=func)
+            return iter(self.get_value(createfunc=func))
         else:
             return BaseQuery.__iter__(self)
 


### PR DESCRIPTION
python expects that __iter__ returns only iterator instances, so we must ensure this always happen, not sure if there are any cases where get_value() itself might return iterator object, but I doubt it since it's used to get the value from the cache and we can't store object instances there, only values
fixes #3 